### PR TITLE
xpath like finders and condensed output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treexml"
-version = "0.3.1"
+version = "0.3.0"
 description = "An XML tree library for Rust"
 keywords = ["xml", "parse", "tree"]
 repository = "https://github.com/rahulg/treexml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treexml"
-version = "0.3.0"
+version = "0.3.1"
 description = "An XML tree library for Rust"
 keywords = ["xml", "parse", "tree"]
 repository = "https://github.com/rahulg/treexml-rs"
@@ -11,3 +11,4 @@ authors = ["Rahul AG <r@hul.ag>"]
 
 [dependencies]
 xml-rs = "0.6"
+error-chain = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT"
 authors = ["Rahul AG <r@hul.ag>"]
 
 [dependencies]
-xml-rs = "0.2"
+xml-rs = "0.6"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To use `treexml`, add the following to your project's `Cargo.toml`
 
 ```toml
 [dependencies]
-treexml = "0.2"
+treexml = "0.3"
 ```
 
 The package exposes a crate named `treexml`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ fn main() {
 
 ## Writing XML Data
 
-```
+```rust
 extern crate treexml;
 
 use treexml::{Document, Element};

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ extern crate treexml;
 
 ## Reading XML Data
 
-Assuming `r` is something that implements `std::io::Read`:
-
 ```rust
 extern crate treexml;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+error_on_line_overflow = false
+write_mode = "Overwrite"
+reorder_imports = true
+reorder_imports_in_group = true
+reorder_imported_names = true
+match_block_trailing_comma = true
+use_try_shorthand = true

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,19 @@
+use xml;
+
+error_chain!{
+    errors {
+        ElementNotFound(t: String) {
+            description("Path returned no elements")
+            display("Element not found: '{}'", t)
+        }
+        ValueFromStr(t: String) {
+            description("Error parsing value")
+            display("Value could not be parsed: '{}'", t)
+        }
+    }
+
+    foreign_links {
+        ParseError(xml::reader::Error);
+        WriteError(xml::writer::Error);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,33 @@ impl Element {
         self.children.iter_mut().find(predicate)
     }
 
+    /// Transverse element using an xpath-like string: root/child/a
+    pub fn find(&self, path: &str) -> Option<&Element> {
+        Self::find_path(&path.split('/').collect::<Vec<&str>>(), &self)
+    }
+
+    pub fn find_text(&self, path: &str) -> &str {
+        self.find(path)
+            .expect(&format!("Could not find {:?}", path))
+            .text.as_ref()
+            .expect(&format!("Path {:?} to have text", path))
+    }
+
+    pub fn find_int(&self, path: &str) -> i32 {
+        self.find_text(path)
+            .parse()
+            .expect(&format!("Path {:?} to be an int", path))
+    }
+
+    fn find_path<'a>(path: &[&str], tree: &'a Element) -> Option<&'a Element> {
+        if path.len() == 0 {
+            return Some(tree);
+        }
+
+        tree.find_child(|t| t.name == path[0])
+            .and_then(|element| Self::find_path(&path[1..], element) )
+    }
+
     /// Filters the children of the current `Element`, given a predicate
     pub fn filter_children<P>(&self, predicate: P) -> Filter<Iter<Element>, P>
         where P: for<'r> Fn(&'r &Element) -> bool
@@ -287,7 +314,6 @@ impl Element {
     {
         self.children.iter_mut().filter(predicate)
     }
-
 }
 
 impl fmt::Display for Element {
@@ -297,7 +323,7 @@ impl fmt::Display for Element {
             .. Document::default()
         };
         let mut v = Vec::<u8>::new();
-        doc._write(&mut v, false, "  ").unwrap();
+        doc.write_with(&mut v, false, "  ", true).unwrap();
         let s = String::from_utf8(v).unwrap();
         f.write_str(&s[..])
     }
@@ -383,16 +409,18 @@ impl Document {
     }
 
     pub fn write<W: Write>(&self, mut w: &mut W) -> Result<(), Error> {
-        self._write(&mut w, true, "  ")
+        self.write_with(&mut w, true, "  ", true)
     }
 
     /// Writes a document to `w`
-    fn _write<W: Write>(&self, w: &mut W, document_decl: bool, indent_str: &'static str) -> Result<(), Error> {
+    pub fn write_with<W: Write>(&self, w: &mut W, document_decl: bool,
+        indent_str: &'static str, indent: bool) -> Result<(), Error> 
+    {
 
         use xml::writer::{EmitterConfig, XmlEvent};
 
         let mut writer = EmitterConfig::new()
-            .perform_indent(true)
+            .perform_indent(indent)
             .write_document_declaration(document_decl)
             .indent_string(indent_str)
             .create_writer(w);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,16 @@
 //!
 //! println!("{}", doc);
 //! ```
+//!
+//!
+
+// `error_chain!` can recurse deeply
+#![recursion_limit = "1024"]
+
+#[macro_use]
+extern crate error_chain;
+
+mod errors;
 
 extern crate xml;
 
@@ -48,46 +58,11 @@ use std::fmt;
 use std::io::{Read, Write};
 use std::iter::Filter;
 use std::slice::{Iter, IterMut};
+use std::str::FromStr;
+
+pub use errors::*;
 
 use xml::common::XmlVersion as BaseXmlVersion;
-
-/// The common error type for all XML tree operations
-#[derive(Debug)]
-pub enum Error {
-    /// Error parsing input data into an XML tree
-    ParseError(xml::reader::Error),
-    WriteError(xml::writer::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::ParseError(ref e) => e.fmt(f),
-            Error::WriteError(ref e) => e.fmt(f),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::ParseError(ref e) => e.description(),
-            Error::WriteError(_) => "Error writing XML element",
-        }
-    }
-}
-
-impl From<xml::reader::Error> for Error {
-    fn from(err: xml::reader::Error) -> Error {
-        Error::ParseError(err)
-    }
-}
-
-impl From<xml::writer::Error> for Error {
-    fn from(err: xml::writer::Error) -> Error {
-        Error::WriteError(err)
-    }
-}
 
 /// Enumeration of XML versions
 ///
@@ -161,10 +136,7 @@ impl Element {
     }
 
     /// Parse the contents of an element
-    fn parse<R: Read>(
-        &mut self,
-        mut reader: &mut xml::reader::EventReader<R>,
-    ) -> Result<(), Error> {
+    fn parse<R: Read>(&mut self, mut reader: &mut xml::reader::EventReader<R>) -> Result<()> {
 
         use xml::reader::XmlEvent;
 
@@ -230,7 +202,7 @@ impl Element {
     }
 
     /// Write an element and its contents to `writer`
-    fn write<W: Write>(&self, writer: &mut xml::writer::EventWriter<W>) -> Result<(), Error> {
+    fn write<W: Write>(&self, writer: &mut xml::writer::EventWriter<W>) -> Result<()> {
 
         use xml::writer::XmlEvent;
         use xml::name::Name;
@@ -288,30 +260,31 @@ impl Element {
     }
 
     /// Transverse element using an xpath-like string: root/child/a
-    pub fn find(&self, path: &str) -> Option<&Element> {
-        Self::find_path(&path.split('/').collect::<Vec<&str>>(), &self)
+    pub fn find(&self, path: &str) -> Result<&Element> {
+        Self::find_path(&path.split('/').collect::<Vec<&str>>(), path, self)
     }
 
-    pub fn find_text(&self, path: &str) -> &str {
-        self.find(path)
-            .expect(&format!("Could not find {:?}", path))
-            .text.as_ref()
-            .expect(&format!("Path {:?} to have text", path))
+    pub fn find_value<T: FromStr>(&self, path: &str) -> Result<Option<T>> {
+        let el = self.find(path)?;
+        if let Some(text) = el.text.as_ref() {
+            match T::from_str(text) {
+                Err(_) => bail!(ErrorKind::ValueFromStr(text.to_string())),
+                Ok(value) => Ok(Some(value)),
+            }
+        } else {
+            Ok(None)
+        }
     }
 
-    pub fn find_int(&self, path: &str) -> i32 {
-        self.find_text(path)
-            .parse()
-            .expect(&format!("Path {:?} to be an int", path))
-    }
-
-    fn find_path<'a>(path: &[&str], tree: &'a Element) -> Option<&'a Element> {
-        if path.len() == 0 {
-            return Some(tree);
+    fn find_path<'a>(path: &[&str], original: &str, tree: &'a Element) -> Result<&'a Element> {
+        if path.is_empty() {
+            return Ok(tree);
         }
 
-        tree.find_child(|t| t.name == path[0])
-            .and_then(|element| Self::find_path(&path[1..], element) )
+        match tree.find_child(|t| t.name == path[0]) {
+            Some(element) => Self::find_path(&path[1..], original, element),
+            None => bail!(ErrorKind::ElementNotFound(original.into())),
+        }
     }
 
     /// Filters the children of the current `Element`, given a predicate
@@ -376,7 +349,7 @@ impl Document {
     /// # Failures
     ///
     /// Passes any errors that the `xml-rs` library returns up the stack
-    pub fn parse<R: Read>(r: R) -> Result<Document, Error> {
+    pub fn parse<R: Read>(r: R) -> Result<Document> {
 
         use xml::reader::{EventReader, XmlEvent};
 
@@ -422,18 +395,18 @@ impl Document {
 
     }
 
-    pub fn write<W: Write>(&self, mut w: &mut W) -> Result<(), Error> {
+    pub fn write<W: Write>(&self, mut w: &mut W) -> Result<()> {
         self.write_with(&mut w, true, "  ", true)
     }
 
     /// Writes a document to `w`
-    fn write_with<W: Write>(
+    pub fn write_with<W: Write>(
         &self,
         w: &mut W,
         document_decl: bool,
         indent_str: &'static str,
         indent: bool,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
 
         use xml::writer::{EmitterConfig, XmlEvent};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,17 +101,17 @@ pub enum XmlVersion {
 }
 
 impl From<BaseXmlVersion> for XmlVersion {
-    fn from(v: BaseXmlVersion) -> XmlVersion {
-        match v {
+    fn from(value: BaseXmlVersion) -> XmlVersion {
+        match value {
             BaseXmlVersion::Version10 => XmlVersion::Version10,
             BaseXmlVersion::Version11 => XmlVersion::Version11,
         }
     }
 }
 
-impl Into<BaseXmlVersion> for XmlVersion {
-    fn into(self) -> BaseXmlVersion {
-        match self {
+impl From<XmlVersion> for BaseXmlVersion {
+    fn from(value: XmlVersion) -> BaseXmlVersion {
+        match value {
             XmlVersion::Version10 => BaseXmlVersion::Version10,
             XmlVersion::Version11 => BaseXmlVersion::Version11,
         }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -113,7 +113,7 @@ mod read {
 
     mod element {
 
-        use treexml::{Document, Element};
+        use treexml::{Document, Element, Error, ErrorKind, Result};
 
         #[test]
         fn find_child_none() {
@@ -272,54 +272,38 @@ mod read {
             let mut leaf = Element::new("leaf");
             leaf.text = Some("1".to_owned());
 
-            assert_eq!(root.find("a/deep/tree/leaf"), Some(&leaf));
+            assert_eq!(root.find("a/deep/tree/leaf").unwrap(), &leaf);
+
+            match root.find("z").unwrap_err() {
+                Error(ErrorKind::ElementNotFound(_), _) => {},
+                _ => panic!("Error should have been ElementNotFound"),
+            }
 
         }
 
         #[test]
-        fn find_text() {
+        fn find_value() {
 
             let doc_raw = r#"
             <root>
-                <a>
-                    <deep>
-                        <tree>
-                            <leaf>hello</leaf>
-                        </tree>
-                    </deep>
-                </a>
-                <child>2</child>
+                <number>2</number>
+                <word>hello</word>
             </root>
             "#;
 
             let doc = Document::parse(doc_raw.as_bytes()).unwrap();
             let root = doc.root.unwrap();
 
-            assert_eq!(root.find_text("a/deep/tree/leaf"), "hello");
+            assert_eq!(root.find_value("number").unwrap(), Some(2));
 
-        }
+            assert_eq!(root.find_value("word").unwrap(), Some("hello".to_string()));
 
-        #[test]
-        fn find_int() {
-
-            let doc_raw = r#"
-            <root>
-                <a>
-                    <deep>
-                        <tree>
-                            <leaf>1</leaf>
-                        </tree>
-                    </deep>
-                </a>
-                <child>2</child>
-            </root>
-            "#;
-
-            let doc = Document::parse(doc_raw.as_bytes()).unwrap();
-            let root = doc.root.unwrap();
-
-            assert_eq!(root.find_int("a/deep/tree/leaf"), 1);
-
+            let cant_parse: Result<Option<i32>> = root.find_value("word");
+            println!("cant parse was {:?}", cant_parse);
+            match cant_parse.unwrap_err() {
+                Error(ErrorKind::ValueFromStr(_), _) => {},
+                _ => panic!("Error should have been ValueFromStr"),
+            }
         }
     }
 

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -249,6 +249,77 @@ mod read {
 
         }
 
+        #[test]
+        fn find() {
+
+            let doc_raw = r#"
+            <root>
+                <a>
+                    <deep>
+                        <tree>
+                            <leaf>1</leaf>
+                        </tree>
+                    </deep>
+                </a>
+                <child>2</child>
+            </root>
+            "#;
+
+            let doc = Document::parse(doc_raw.as_bytes()).unwrap();
+            let root = doc.root.unwrap();
+
+            let mut leaf = Element::new("leaf");
+            leaf.text = Some("1".to_owned());
+
+            assert_eq!(root.find("a/deep/tree/leaf"), Some(&leaf));
+
+        }
+
+        #[test]
+        fn find_text() {
+
+            let doc_raw = r#"
+            <root>
+                <a>
+                    <deep>
+                        <tree>
+                            <leaf>hello</leaf>
+                        </tree>
+                    </deep>
+                </a>
+                <child>2</child>
+            </root>
+            "#;
+
+            let doc = Document::parse(doc_raw.as_bytes()).unwrap();
+            let root = doc.root.unwrap();
+
+            assert_eq!(root.find_text("a/deep/tree/leaf"), "hello");
+
+        }
+
+        #[test]
+        fn find_int() {
+
+            let doc_raw = r#"
+            <root>
+                <a>
+                    <deep>
+                        <tree>
+                            <leaf>1</leaf>
+                        </tree>
+                    </deep>
+                </a>
+                <child>2</child>
+            </root>
+            "#;
+
+            let doc = Document::parse(doc_raw.as_bytes()).unwrap();
+            let root = doc.root.unwrap();
+
+            assert_eq!(root.find_int("a/deep/tree/leaf"), 1);
+
+        }
     }
 
     mod cdata {

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -250,6 +250,77 @@ mod read {
 
         }
 
+        #[test]
+        fn find() {
+
+            let doc_raw = r#"
+            <root>
+                <a>
+                    <deep>
+                        <tree>
+                            <leaf>1</leaf>
+                        </tree>
+                    </deep>
+                </a>
+                <child>2</child>
+            </root>
+            "#;
+
+            let doc = Document::parse(doc_raw.as_bytes()).unwrap();
+            let root = doc.root.unwrap();
+
+            let mut leaf = Element::new("leaf");
+            leaf.text = Some("1".to_owned());
+
+            assert_eq!(root.find("a/deep/tree/leaf"), Some(&leaf));
+
+        }
+
+        #[test]
+        fn find_text() {
+
+            let doc_raw = r#"
+            <root>
+                <a>
+                    <deep>
+                        <tree>
+                            <leaf>hello</leaf>
+                        </tree>
+                    </deep>
+                </a>
+                <child>2</child>
+            </root>
+            "#;
+
+            let doc = Document::parse(doc_raw.as_bytes()).unwrap();
+            let root = doc.root.unwrap();
+
+            assert_eq!(root.find_text("a/deep/tree/leaf"), "hello");
+
+        }
+
+        #[test]
+        fn find_int() {
+
+            let doc_raw = r#"
+            <root>
+                <a>
+                    <deep>
+                        <tree>
+                            <leaf>1</leaf>
+                        </tree>
+                    </deep>
+                </a>
+                <child>2</child>
+            </root>
+            "#;
+
+            let doc = Document::parse(doc_raw.as_bytes()).unwrap();
+            let root = doc.root.unwrap();
+
+            assert_eq!(root.find_int("a/deep/tree/leaf"), 1);
+
+        }
     }
 
     mod cdata {

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -3,7 +3,7 @@ extern crate treexml;
 mod read {
 
     mod document {
-        
+
         use treexml::{Document, XmlVersion};
 
         #[test]
@@ -232,7 +232,8 @@ mod read {
             let mut root = doc.root.unwrap();
 
             {
-                let mut children: Vec<&mut Element> = root.filter_children_mut(|t| t.name == "child").collect();
+                let mut children: Vec<&mut Element> =
+                    root.filter_children_mut(|t| t.name == "child").collect();
                 children[0].text = Some("4".to_owned());
                 children[1].text = Some("5".to_owned());
             }
@@ -346,7 +347,7 @@ mod read {
             root.children.push(c3);
             root.children.push(c4);
 
-            let doc_ref = Document{
+            let doc_ref = Document {
                 version: XmlVersion::Version11,
                 encoding: "UTF-8".to_owned(),
                 root: Some(root),

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -167,36 +167,4 @@ mod write {
 
     }
 
-    mod builder {
-        use treexml::{Document, Element};
-
-        #[test]
-        fn incremental_builder() {
-
-            let mut root = Element::new("root");
-            root.cdata = Some("data".to_owned());
-
-            let doc = Document{
-                root: Some(root),
-                .. Document::default()
-            };
-
-            let doc_ref = concat!(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
-                "<root>\n",
-                "  <list>\n",
-                "    <child />\n",
-                "    <child class=\"foo\">bar</child>\n",
-                "    <child class=\"22\">11</child>\n",
-                "  </list>\n",
-                "  <![CDATA[data]]>\n",
-                "</root>"
-            );
-
-            assert_eq!(doc.to_string(), doc_ref);
-
-        }
-
-    }
-
 }

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -29,6 +29,25 @@ mod write {
 
         }
 
+        #[test]
+        fn condensed_document() {
+
+            let mut root = Element::new("root");
+            let child = Element::new("child");
+            root.children.push(child);
+
+            let doc = Document{
+                root: Some(root),
+                .. Document::default()
+            };
+
+            let mut condensed = vec![];
+            doc.write_with(&mut condensed, false, "", false).unwrap();
+        
+            assert_eq!(String::from_utf8(condensed).unwrap(),
+                "<root><child /></root>");
+        }
+
     }
 
     mod element {

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -167,4 +167,36 @@ mod write {
 
     }
 
+    mod builder {
+        use treexml::{Document, Element};
+
+        #[test]
+        fn incremental_builder() {
+
+            let mut root = Element::new("root");
+            root.cdata = Some("data".to_owned());
+
+            let doc = Document{
+                root: Some(root),
+                .. Document::default()
+            };
+
+            let doc_ref = concat!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+                "<root>\n",
+                "  <list>\n",
+                "    <child />\n",
+                "    <child class=\"foo\">bar</child>\n",
+                "    <child class=\"22\">11</child>\n",
+                "  </list>\n",
+                "  <![CDATA[data]]>\n",
+                "</root>"
+            );
+
+            assert_eq!(doc.to_string(), doc_ref);
+
+        }
+
+    }
+
 }

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -36,16 +36,18 @@ mod write {
             let child = Element::new("child");
             root.children.push(child);
 
-            let doc = Document{
+            let doc = Document {
                 root: Some(root),
-                .. Document::default()
+                ..Document::default()
             };
 
             let mut condensed = vec![];
             doc.write_with(&mut condensed, false, "", false).unwrap();
-        
-            assert_eq!(String::from_utf8(condensed).unwrap(),
-                "<root><child /></root>");
+
+            assert_eq!(
+                String::from_utf8(condensed).unwrap(),
+                "<root><child /></root>"
+            );
         }
 
     }
@@ -90,7 +92,8 @@ mod write {
                 ..Document::default()
             };
 
-            let doc_ref = concat!(
+            let doc_ref =
+                concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root>text</root>",
             );
@@ -110,7 +113,8 @@ mod write {
                 ..Document::default()
             };
 
-            let doc_ref = concat!(
+            let doc_ref =
+                concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root>&lt;tag /></root>",
             );
@@ -136,7 +140,8 @@ mod write {
                 ..Document::default()
             };
 
-            let doc_ref = concat!(
+            let doc_ref =
+                concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root><![CDATA[data]]></root>",
             );
@@ -156,7 +161,8 @@ mod write {
                 ..Document::default()
             };
 
-            let doc_ref = concat!(
+            let doc_ref =
+                concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root><![CDATA[<tag />]]></root>",
             );

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -3,7 +3,7 @@ extern crate treexml;
 mod write {
 
     mod document {
-        
+
         use treexml::{Document, Element};
 
         #[test]
@@ -13,11 +13,11 @@ mod write {
             let child = Element::new("child");
             root.children.push(child);
 
-            let doc = Document{
+            let doc = Document {
                 root: Some(root),
-                .. Document::default()
+                ..Document::default()
             };
-        
+
             let doc_ref = concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root>\n",
@@ -43,9 +43,9 @@ mod write {
             let child2 = Element::new("child").clone();
             root.children.push(child);
 
-            let _ = Document{
+            let _ = Document {
                 root: Some(root),
-                .. Document::default()
+                ..Document::default()
             };
 
             let elem_ref = "<child />";
@@ -66,9 +66,9 @@ mod write {
             let mut root = Element::new("root");
             root.text = Some("text".to_owned());
 
-            let doc = Document{
+            let doc = Document {
                 root: Some(root),
-                .. Document::default()
+                ..Document::default()
             };
 
             let doc_ref = concat!(
@@ -86,9 +86,9 @@ mod write {
             let mut root = Element::new("root");
             root.text = Some("<tag />".to_owned());
 
-            let doc = Document{
+            let doc = Document {
                 root: Some(root),
-                .. Document::default()
+                ..Document::default()
             };
 
             let doc_ref = concat!(
@@ -112,9 +112,9 @@ mod write {
             let mut root = Element::new("root");
             root.cdata = Some("data".to_owned());
 
-            let doc = Document{
+            let doc = Document {
                 root: Some(root),
-                .. Document::default()
+                ..Document::default()
             };
 
             let doc_ref = concat!(
@@ -132,9 +132,9 @@ mod write {
             let mut root = Element::new("root");
             root.cdata = Some("<tag />".to_owned());
 
-            let doc = Document{
+            let doc = Document {
                 root: Some(root),
-                .. Document::default()
+                ..Document::default()
             };
 
             let doc_ref = concat!(


### PR DESCRIPTION
Hi,

Sorry for the compound pull request, you may not want to merge this right away.

But I think this library is a good abstraction, although it seems to be abandoned.

I've been tinkering with adding xpath like support for transversing the XML and also for parsing/casting the contents.

Also, I've exposed the underlying 'write' as a public method so that users can tinker a bit with the ouput indentation (I needed to produce and digitally sign condensed output)

If any of this is of your interest I'm willing to clean up the API, maybe add error-chain too.

Best regards!
----nubis