### PR TITLE
made builder pattern more friendly to literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,20 @@ use treexml::Document;
 
 fn main() {
 
-	let doc_raw = r#"
-	<?xml version="1.1" encoding="UTF-8"?>
-	<table>
-		<fruit type="apple">worm</fruit>
-		<vegetable />
-	</table>
-	"#;
+    let doc_raw = r#"
+    <?xml version="1.1" encoding="UTF-8"?>
+    <table>
+        <fruit type="apple">worm</fruit>
+        <vegetable />
+    </table>
+    "#;
 
-	let doc = Document::parse(doc_raw.as_bytes()).unwrap();
-	let root = doc.root.unwrap();
+    let doc = Document::parse(doc_raw.as_bytes()).unwrap();
+    let root = doc.root.unwrap();
 
-	let fruit = root.find_child(|tag| tag.name == "fruit").unwrap().clone();
-	println!("{} [{:?}] = {}", fruit.name, fruit.attributes, fruit.contents.unwrap());
-	
+    let fruit = root.find_child(|tag| tag.name == "fruit").unwrap().clone();
+    println!("{} [{:?}] = {}", fruit.name, fruit.attributes, fruit.contents.unwrap());
+    
 }
 ```
 
@@ -52,22 +52,23 @@ extern crate treexml;
 use treexml::{Document, ElementBuilder as E};
 
 fn main() {
+    let mut something = E::new("something");
+    root.attr("key", "value");
+    root.text("some-text");
 
-	let root = E::new("root").children(vec![
-		E::new("list").children(vec![
-			E::new("child").element(),
-			E::new("child").cdata("test data here").element(),
-			E::new("child").attr("class", "foo").text("bar").element(),
-			E::new("child").attr("class", 22).text(11).element(),
-		]).element(),
-	]).element();
+    let doc = Document::build(
+        E::new("root").children(vec![
+            E::new("list").children(vec![
+                E::new("child").cdata("test data here"),
+                E::new("child").attr("class", "foo").text("bar"),
+                E::new("child").attr("class", 22).text(11),
+                &mut E::new("child"),
+                &mut something,
+            ]),
+        ])
+    );
 
-	let doc = Document{
-		root: Some(root),
-		..Document::default()
-	};
-
-	println!("{}", doc);
+    println!("{}", doc);
 
 }
 ```

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+/// A builder for Element
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ElementBuilder {
+    /// The XML element we're working on
+    element: Element,
+}
+
+impl ElementBuilder {
+    /// Create a builder for an `Element` with the tag name `name`
+    pub fn new<S>(name: S) -> ElementBuilder
+    where
+        S: ToString,
+    {
+        ElementBuilder { element: Element::new(name) }
+    }
+
+    /// Set the element's prefix to `prefix`
+    pub fn prefix<S>(&mut self, prefix: S) -> &mut ElementBuilder
+    where
+        S: ToString,
+    {
+        self.element.prefix = Some(prefix.to_string());
+        self
+    }
+
+    /// Set the element's attribute `key` to `value`
+    pub fn attr<K, V>(&mut self, key: K, value: V) -> &mut ElementBuilder
+    where
+        K: ToString,
+        V: ToString,
+    {
+        self.element.attributes.insert(
+            key.to_string(),
+            value.to_string(),
+        );
+        self
+    }
+
+    /// Set the element's text to `text`
+    pub fn text<S>(&mut self, text: S) -> &mut ElementBuilder
+    where
+        S: ToString,
+    {
+        self.element.text = Some(text.to_string());
+        self
+    }
+
+    /// Set the element's CDATA to `cdata`
+    pub fn cdata<S>(&mut self, cdata: S) -> &mut ElementBuilder
+    where
+        S: ToString,
+    {
+        self.element.cdata = Some(cdata.to_string());
+        self
+    }
+
+    /// Append children to this `Element`
+    pub fn children(&mut self, children: Vec<&mut ElementBuilder>) -> &mut ElementBuilder {
+        self.element.children.append(&mut children
+            .into_iter()
+            .map(|i| i.element())
+            .collect());
+        self
+    }
+
+    /// Creates an `Element` from the builder
+    pub fn element(&self) -> Element {
+        self.element.clone()
+    }
+}
+
+impl From<ElementBuilder> for Element {
+    fn from(value: ElementBuilder) -> Element {
+        value.element()
+    }
+}
+
+impl From<Element> for ElementBuilder {
+    fn from(element: Element) -> ElementBuilder {
+        ElementBuilder { element }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@ mod errors;
 
 extern crate xml;
 
+mod builder;
+
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
@@ -62,6 +64,8 @@ use std::str::FromStr;
 use std::string::ToString;
 
 pub use errors::*;
+
+pub use builder::*;
 
 use xml::common::XmlVersion as BaseXmlVersion;
 
@@ -91,73 +95,6 @@ impl From<XmlVersion> for BaseXmlVersion {
             XmlVersion::Version10 => BaseXmlVersion::Version10,
             XmlVersion::Version11 => BaseXmlVersion::Version11,
         }
-    }
-}
-
-/// A builder for Element
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ElementBuilder {
-    /// The XML element we're working on
-    element: Element,
-}
-
-impl ElementBuilder {
-    /// Create a builder for an `Element` with the tag name `name`
-    pub fn new<S>(name: S) -> ElementBuilder
-    where
-        S: ToString,
-    {
-        ElementBuilder { element: Element::new(name) }
-    }
-
-    /// Set the element's prefix to `prefix`
-    pub fn prefix<S>(&mut self, prefix: S) -> &mut ElementBuilder
-    where
-        S: ToString,
-    {
-        self.element.prefix = Some(prefix.to_string());
-        self
-    }
-
-    /// Set the element's attribute `key` to `value`
-    pub fn attr<K, V>(&mut self, key: K, value: V) -> &mut ElementBuilder
-    where
-        K: ToString,
-        V: ToString,
-    {
-        self.element
-            .attributes
-            .insert(key.to_string(), value.to_string());
-        self
-    }
-
-    /// Set the element's text to `text`
-    pub fn text<S>(&mut self, text: S) -> &mut ElementBuilder
-    where
-        S: ToString,
-    {
-        self.element.text = Some(text.to_string());
-        self
-    }
-
-    /// Set the element's CDATA to `cdata`
-    pub fn cdata<S>(&mut self, cdata: S) -> &mut ElementBuilder
-    where
-        S: ToString,
-    {
-        self.element.cdata = Some(cdata.to_string());
-        self
-    }
-
-    /// Append children to this `Element`
-    pub fn children(&mut self, mut children: Vec<Element>) -> &mut ElementBuilder {
-        self.element.children.append(&mut children);
-        self
-    }
-
-    /// Creates an `Element` from the builder
-    pub fn element(&self) -> Element {
-        self.element.clone()
     }
 }
 
@@ -410,6 +347,14 @@ impl Document {
     /// Create a new `Document` with default values
     pub fn new() -> Document {
         Document { ..Document::default() }
+    }
+
+    /// Create a new `Document` with an Element or ElementBuilder.at its root.
+    pub fn build(root: &mut ElementBuilder) -> Self {
+        Document {
+            root: Some(root.element()),
+            ..Self::default()
+        }
     }
 
     /// Parse data from a reader to construct an XML document

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -92,7 +92,8 @@ mod write {
                 ..Document::default()
             };
 
-            let doc_ref = concat!(
+            let doc_ref =
+                concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root>text</root>",
             );
@@ -112,7 +113,8 @@ mod write {
                 ..Document::default()
             };
 
-            let doc_ref = concat!(
+            let doc_ref =
+                concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root>&lt;tag /></root>",
             );
@@ -138,7 +140,8 @@ mod write {
                 ..Document::default()
             };
 
-            let doc_ref = concat!(
+            let doc_ref =
+                concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root><![CDATA[data]]></root>",
             );
@@ -158,7 +161,8 @@ mod write {
                 ..Document::default()
             };
 
-            let doc_ref = concat!(
+            let doc_ref =
+                concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root><![CDATA[<tag />]]></root>",
             );
@@ -170,38 +174,27 @@ mod write {
     }
 
     mod builder {
-        use treexml::{Document, ElementBuilder};
+        use treexml::{Document, Element, ElementBuilder as E};
 
         #[test]
         fn incremental_build() {
 
-            let root = ElementBuilder::new("root")
-                .children(vec![
-                    ElementBuilder::new("list")
-                        .children(vec![
-                            ElementBuilder::new("child").element(),
-                            ElementBuilder::new("child")
-                                .attr("class", "foo")
-                                .text("bar")
-                                .element(),
-                            ElementBuilder::new("child")
-                                .attr("class", 22.to_string())
-                                .text(11.to_string())
-                                .element(),
-                        ])
-                        .element(),
-                ])
-                .element();
+            let preexisting: Element = E::new("preexisting").element();
 
-            let doc = Document {
-                root: Some(root),
-                ..Document::default()
-            };
+            let doc = Document::build(E::new("root").children(vec![
+                E::new("list").children(vec![
+                        &mut preexisting.into(),
+                        &mut E::new("child"),
+                        E::new("child").attr("class", "foo").text("bar"),
+                        E::new("child").attr("class", 22).text(11),
+                    ]),
+            ]));
 
             let doc_ref = concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                 "<root>\n",
                 "  <list>\n",
+                "    <preexisting />\n",
                 "    <child />\n",
                 "    <child class=\"foo\">bar</child>\n",
                 "    <child class=\"22\">11</child>\n",
@@ -215,14 +208,11 @@ mod write {
 
         #[test]
         fn incremental_build_multiline() {
-            let mut root = ElementBuilder::new("root");
+            let mut root = E::new("root");
             root.attr("key", "value");
             root.text("some-text");
 
-            let doc = Document {
-                root: Some(root.element()),
-                ..Document::default()
-            };
+            let doc = Document::build(&mut root);
 
             let doc_ref = concat!(
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",


### PR DESCRIPTION
Sorry to keep pushing with this, but the verbosity of calling .element() each time is almost defeating the purpose for my particular use, where I have a rather large (30 children) XML that I want to build directly in my rust code as a literal, without using a templating library.

I also added nice conversions from ElementBuilder and Element so we can use into() to convert between them.

Also added a helper method for the usual pattern where you build a Doc from a root node and default everything else.

I moved the builder to its own file, and made sure to rebase properly so this should merge smoothly. If it doesn't then I'm reading the whole git book.

Hope this helps :)